### PR TITLE
Add script to check file size and md5sum of checkpoint on Google Cloud Storage

### DIFF
--- a/pretrain/scripts/v3-megatron-gcp/calculate_combined_md5.sh
+++ b/pretrain/scripts/v3-megatron-gcp/calculate_combined_md5.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# This script calculates the md5sum of all files in a given directory (and its subdirectories)
+# and outputs the combined md5sum using parallel processing for faster execution.
+#
+# How to use:
+# bash calculate_combined_md5.sh $LOCAL_DIR
+# > xxxxxxxxxxx(md5sum)
+
+if [ -z "$1" ]; then
+  echo "Usage: $0 <directory>"
+  exit 1
+fi
+
+DIRECTORY=$1
+
+if [ ! -d "$DIRECTORY" ]; then
+  echo "Error: Directory $DIRECTORY does not exist."
+  exit 1
+fi
+
+# Create a temporary file to store individual md5sums
+temp_file=$(mktemp)
+
+# Find all files and calculate their md5sums in parallel, store results in the temp file
+find "$DIRECTORY" -type f | xargs -P 80 -I {} md5sum "{}" | awk '{print $1}' >> "$temp_file"
+
+# Sort the results and calculate the combined md5sum
+combined_md5=$(sort "$temp_file" | md5sum | awk '{print $1}')
+
+# Clean up the temporary file
+rm "$temp_file"
+
+echo "$combined_md5"
+

--- a/pretrain/scripts/v3-megatron-gcp/calculate_combined_md5.sh
+++ b/pretrain/scripts/v3-megatron-gcp/calculate_combined_md5.sh
@@ -7,7 +7,7 @@
 # bash calculate_combined_md5.sh $LOCAL_DIR
 # > xxxxxxxxxxx(md5sum)
 
-if [ -z "$1" ]; then
+if [ $# -ne 1 ]; then
   echo "Usage: $0 <directory>"
   exit 1
 fi

--- a/pretrain/scripts/v3-megatron-gcp/calculate_gcloud_combined_md5.sh
+++ b/pretrain/scripts/v3-megatron-gcp/calculate_gcloud_combined_md5.sh
@@ -1,0 +1,42 @@
+
+#!/bin/bash
+
+# This script calculates the combined md5sum of all files in a given Google Cloud Storage bucket/directory.
+# The combined md5sum is calculated by fetching the md5sums of each file and then combining them.
+#
+# How to use:
+# bash calculate_gcloud_combined_md5.sh $GOOGLE_CLOUD_DIR
+# > xxxxxxxxxxx(md5sum)
+
+if [ -z "$1" ]; then
+  echo "Usage: $0 <gcs-directory>"
+  exit 1
+fi
+
+GCS_DIRECTORY=$1
+
+# Create a temporary file to store individual md5sums
+temp_file=$(mktemp)
+
+# Function to convert base64 md5 to hex
+base64_to_hex() {
+  echo "$1" | base64 --decode | od -An -t x1 | tr -d ' \n'
+}
+
+# List all files in the GCS directory and fetch their md5sums
+gsutil ls -r "$GCS_DIRECTORY/**" | grep -v '/$' | while read -r file; do
+  md5_base64=$(gsutil stat "$file" | grep "Hash (md5)" | awk '{print $3}')
+  if [ -n "$md5_base64" ]; then
+    md5_hex=$(base64_to_hex "$md5_base64")
+    echo "$md5_hex"
+  fi
+done > "$temp_file"
+
+# Sort the md5 sums and calculate the combined md5sum
+combined_md5=$(sort "$temp_file" | md5sum | awk '{print $1}')
+
+# Clean up the temporary file
+rm "$temp_file"
+
+echo "$combined_md5"
+

--- a/pretrain/scripts/v3-megatron-gcp/calculate_gcloud_combined_md5.sh
+++ b/pretrain/scripts/v3-megatron-gcp/calculate_gcloud_combined_md5.sh
@@ -8,7 +8,7 @@
 # bash calculate_gcloud_combined_md5.sh $GOOGLE_CLOUD_DIR
 # > xxxxxxxxxxx(md5sum)
 
-if [ -z "$1" ]; then
+if [ $# -ne 1 ]; then
   echo "Usage: $0 <gcs-directory>"
   exit 1
 fi

--- a/pretrain/scripts/v3-megatron-gcp/check_cloud_checkpoints.sh
+++ b/pretrain/scripts/v3-megatron-gcp/check_cloud_checkpoints.sh
@@ -4,7 +4,7 @@
 # If the file sizes are different, an error is output.
 # 
 # How to use:
-# $ bash check_cloud_filesize.sh
+# $ bash check_cloud_checkpoints.sh
 # > iter_xxxx Local size:yyyy Cloud size:yyyy
 # > iter_xxx Local md5sum:hogehoge Cloud md5sum:hogehoge
 # If the file sizes are different

--- a/pretrain/scripts/v3-megatron-gcp/check_cloud_checkpoints.sh
+++ b/pretrain/scripts/v3-megatron-gcp/check_cloud_checkpoints.sh
@@ -22,5 +22,15 @@ for iter in $(ls ${LOCAL_CKPT_DIR} | grep iter_); do
 	if [ "$local_size" -ne "$cloud_size" ]; then
 		echo "Error: ${iter} file sizes are different."
 	fi
+
+	local_combine_md5=$(bash calculate_combined_md5.sh ${LOCAL_CKPT_DIR}/${iter})
+	cloud_combine_md5=$(bash calculate_gcloud_combined_md5.sh ${CLOUD_CKPT_DIR}/${iter})
+
+	echo "${iter} Local md5sum:$local_combine_md5 Cloud md5sum:$cloud_combine_md5"
+
+	if [ "$local_combine_md5" != "$cloud_combine_md5" ]; then
+		echo "Error: ${iter} md5 checksums are different."
+	fi
+
 done
 

--- a/pretrain/scripts/v3-megatron-gcp/check_cloud_checkpoints.sh
+++ b/pretrain/scripts/v3-megatron-gcp/check_cloud_checkpoints.sh
@@ -6,10 +6,13 @@
 # How to use:
 # $ bash check_cloud_filesize.sh
 # > iter_xxxx Local size:yyyy Cloud size:yyyy
+# > iter_xxx Local md5sum:hogehoge Cloud md5sum:hogehoge
 # If the file sizes are different
 # > iter_xxxx Local size:yyyy Cloud size:zzzz
 # > Error: iter_xxxx file sizes are different.
- 
+# > iter_xxxx Local md5sum:hogehoge Cloud md5sum:hugehuge
+# > Error: iter_xxx md5 checksums are different.
+
 LOCAL_CKPT_DIR="/lustre/checkpoints/llama-2-172b-exp2/tp4-pp16-cp1" # FIXME: DIR_PATH to checkpoint on local storage
 CLOUD_CKPT_DIR="gs://llama2-172b-checkpoint-exp2" # FIXME: DIR_PATH to checkpoint on Google Cloud Storage
 


### PR DESCRIPTION
Compare checkpoint file sizes and md5 checksums between Google Cloud Storage and local storage.

## How to use
```
$ bash check_cloud_checkpoints.sh
iter_xxxx Local size:yyyy Cloud size:yyyy
iter_xxx Local md5sum:hogehoge Cloud md5sum:hogehoge
```

If the file sizes or md5 checksums are different.
```
$ bash check_cloud_checkpoints.sh
iter_xxxx Local size:yyyy Cloud size:zzzz
Error: iter_xxxx file sizes are different.
iter_xxxx Local md5sum:hogehoge Cloud md5sum:hugehuge
Error: iter_xxx md5 checksums are different.
```