### PR TITLE
Specify number of CPUs/RAM for installer jobs

### DIFF
--- a/pretrain/installers/v3-megatron-sakura/install.sh
+++ b/pretrain/installers/v3-megatron-sakura/install.sh
@@ -16,6 +16,8 @@
 #SBATCH --partition=cpu
 #SBATCH --nodes=1
 #SBATCH --ntasks-per-node=1
+#SBATCH --cpus-per-task=72
+#SBATCH --mem=1920G
 #SBATCH --output=%x-%j.out
 #SBATCH --error=%x-%j.err
 

--- a/pretrain/installers/v3-megatron-sakura/install.sh
+++ b/pretrain/installers/v3-megatron-sakura/install.sh
@@ -14,7 +14,7 @@
 
 #SBATCH --job-name=pretrain-install
 #SBATCH --partition=cpu
-#SBATCH --exclusive=topo
+#SBATCH --exclusive
 #SBATCH --nodes=1
 #SBATCH --ntasks-per-node=1
 #SBATCH --mem=0

--- a/pretrain/installers/v3-megatron-sakura/install.sh
+++ b/pretrain/installers/v3-megatron-sakura/install.sh
@@ -14,10 +14,10 @@
 
 #SBATCH --job-name=pretrain-install
 #SBATCH --partition=cpu
+#SBATCH --exclusive=topo
 #SBATCH --nodes=1
 #SBATCH --ntasks-per-node=1
-#SBATCH --cpus-per-task=72
-#SBATCH --mem=1920G
+#SBATCH --mem=0
 #SBATCH --output=%x-%j.out
 #SBATCH --error=%x-%j.err
 


### PR DESCRIPTION
Add slurm options to specify explicit amount of CPUs and RAM for the installer job.
Since the previous version of the installer hasn't specify them, it runs on only 1 CPU power in spite of the actual amount of resources.