### PR TITLE
Use mktemp to create temporal working directory

### DIFF
--- a/pretrain/scripts/v3-converter/convert.sh
+++ b/pretrain/scripts/v3-converter/convert.sh
@@ -49,8 +49,8 @@ fi
 
 # Create a unique temporal working directory to avoid affecting the original directory and
 # to allow multiple runs to execute simultaneously.
-TMP_DIR=${HOME}/ckpt_convert_$(date +%Y%m%d%H%M%S)
-mkdir -p "${TMP_DIR}"
+TMP_DIR=$(mktemp -d "${HOME}/ckpt_convert.XXXXXXXX")
+>&2 echo TMP_DIR=$TMP_DIR 
 ln -s $(readlink -f $MEGATRON_CHECKPOINT_DIR) ${TMP_DIR}/${TARGET_ITER_DIR}
 echo $ITER > "${TMP_DIR}/latest_checkpointed_iteration.txt"
 


### PR DESCRIPTION
When model conversions are executed simultaneously within the same second, temporary working directories are duplicated. To address this issue, `mktemp` is used to create temporary directories.