### PR TITLE
Change SLURM option in model parameter convert

### DIFF
--- a/pretrain/scripts/v3-converter/README.md
+++ b/pretrain/scripts/v3-converter/README.md
@@ -26,6 +26,7 @@
     ```
 
 3. スクリプトを実行します：
+  - SLURMで実行する際には、`--mem`オプションをモデルサイズの2倍以上にしてください。
     ```shell
     # For a cluster with SLURM
     sbatch --partition {partition} convert.sh SOURCE_DIR TARGET_DIR

--- a/pretrain/scripts/v3-converter/convert.sh
+++ b/pretrain/scripts/v3-converter/convert.sh
@@ -21,8 +21,7 @@
 #SBATCH --gpus=1
 #SBATCH --ntasks-per-node=1
 #SBATCH --cpus-per-task=8
-#SBATCH --mem=0
-#SBATCH --exclusive
+#SBATCH --mem=400G
 #SBATCH --output=outputs/%x-%j.out
 #SBATCH --error=outputs/%x-%j.err
 


### PR DESCRIPTION
This PR change SLURM option in model parameter format convert not to use whole node by one job in default.