### PR TITLE
Make installed llm-jp-eval editable

### DIFF
--- a/evaluation/installers/llm-jp-eval-v1.4.1/install.sh
+++ b/evaluation/installers/llm-jp-eval-v1.4.1/install.sh
@@ -89,7 +89,7 @@ if [ -n "$LLM_JP_EVAL_BUG_FIX_COMMIT_IDS" ]; then
 fi
 pip install --no-cache-dir -r requirements.txt
 pip install --no-cache-dir -r ${ENV_DIR}/requirements-eval.txt
-pip install --no-cache-dir .
+pip install --no-cache-dir -e .
 
 INFERENCE_SCRIPT=offline_inference/vllm/offline_inference_vllm.py
 # Remove execution time due to its complexity in handling


### PR DESCRIPTION
SSIA

普通にインストールしてしまうと後で手入れするのが面倒なため。