### PR TITLE
Fix v4-megatron-abci installer

### DIFF
--- a/pretrain/installers/v4-megatron-abci/qsub_setup.sh
+++ b/pretrain/installers/v4-megatron-abci/qsub_setup.sh
@@ -1,11 +1,4 @@
 #!/bin/bash
-#PBS -P gcg51557
-#PBS -q R10415
-#PBS -v RTYPE=rt_HF
-#PBS -l select=1
-#PBS -l walltime=01:00:00
-#PBS -o /dev/null
-#PBS -e /dev/null
 
 cd $PBS_O_WORKDIR
 

--- a/pretrain/installers/v4-megatron-abci/run_setup.sh
+++ b/pretrain/installers/v4-megatron-abci/run_setup.sh
@@ -2,17 +2,22 @@
 
 set -eu -o pipefail
 
-if [ $# -ne 1 ]; then
-    >&2 echo "Usage: $0 <target-dir>"
-    >&2 echo "Example: $0 /path/to/target_dir"
+if [ $# -ne 2 ]; then
+    >&2 echo "Usage: $0 <target-dir> <reservation-id>"
+    >&2 echo "Example: $0 /path/to/target_dir R01234567890"
     exit 1
 fi
 
 target_dir=$1; shift
+reservation_id=$1; shift
 
 qsub \
+  -P gcg51557 \
+  -q ${reservation_id} \
   -v TARGET_DIR=${target_dir},RTYPE=rt_HF \
-  -o /dev/null -e /dev/null \
   -m n \
+  -o /dev/null \
+  -e /dev/null \
+  -l select=1,walltime=01:00:00 \
   qsub_setup.sh
 


### PR DESCRIPTION
* PBS変数を `run_setup.sh` 側に寄せる
* 予約IDを引数化しスクリプトから削除