### PR TITLE
add NUM_NODES variable to converter launcher

### DIFF
--- a/pretrain/scripts/v4-corpus-ratio-abci/convert/run_convert.sh
+++ b/pretrain/scripts/v4-corpus-ratio-abci/convert/run_convert.sh
@@ -2,9 +2,9 @@
 
 set -eu -o pipefail
 
-if [ $# -ne 4 ]; then
-    >&2 echo "Usage: $0 <RESERVATION_ID> <EXPERIMENT_ID> <EXPERIMENT_DIR> <TASK_NAME>"
-    >&2 echo "Example: $0 R0123456789 0123 /path/to/0123_experiment task_name"
+if [ $# -ne 5 ]; then
+    >&2 echo "Usage: $0 <RESERVATION_ID> <EXPERIMENT_ID> <EXPERIMENT_DIR> <TASK_NAME> <NUM_NODES>"
+    >&2 echo "Example: $0 R0123456789 0123 /path/to/0123_experiment task_name 1"
     exit 1
 fi
 
@@ -14,6 +14,7 @@ RESERVATION_ID=$1; shift
 EXPERIMENT_ID=$1; shift
 EXPERIMENT_DIR=$1; shift
 TASK_NAME=$1; shift
+NUM_NODES=$1; shift
 
 # This directory
 SCRIPT_ROOT=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
@@ -39,7 +40,7 @@ for iter in $(seq 1000 1000 ${LAST_ITER}); do
         -P gcg51557 \
         -q ${RESERVATION_ID} \
         -N ${EXPERIMENT_ID}_convert \
-        -l select=1,walltime=6:00:00 \
+        -l select=${NUM_NODES},walltime=6:00:00 \
         -v RTYPE=rt_HF,EXPERIMENT_DIR=${EXPERIMENT_DIR},TASK_NAME=${TASK_NAME},ITER=${iter} \
         -o /dev/null \
         -e /dev/null \


### PR DESCRIPTION
Megatron->HF コンバータがABCI 1ノードで動かないケースがあるので、ノード数を指定するオプションを追加。