### PR TITLE
Apply some modifications to the qsub of the model evaluation pipeline

### DIFF
--- a/evaluation/installers/intg-eval-2508/README.md
+++ b/evaluation/installers/intg-eval-2508/README.md
@@ -81,6 +81,7 @@ bash $INSTALL_DIR/scripts/run_eval.sh \
 python3 $INSTALL_DIR/scripts/qsub.py \
   <model_name_or_absolute_path> \
   <output_dir_absolute_path> \
+  [--experiment_dir /groups/gcg51557/experiments/0182_intg_eval_2507] \
   [--swallow_version v202411] \
   [--llm_jp_eval_version v1.4.1] \
   [--job_name 0182_intg_eval] \
@@ -90,10 +91,11 @@ python3 $INSTALL_DIR/scripts/qsub.py \
 ```
 
 必須引数:
-- `<model_name_or_absolute_path>` モデル名またはモデルの絶対パス
+- `<model_name_or_absolute_path>` モデル名またはモデルの絶対パス(HFのモデル名を指定する場合は[モデル名を指定する場合](##モデル名を指定する場合)を参照)
 - `<output_dir_absolute_path>` 結果出力先の絶対パス
 
 オプション引数:
+- `--experiment_dir` 評価環境がインストールされた実験ディレクトリのパス (デフォルト: `/groups/gcg51557/experiments/0182_intg_eval_2507`)
 - `--swallow_version` swallowバージョン（デフォルト: `v202411`）現状は`v202411`のみに対応。
 - `--llm_jp_eval_version` llm-jp-evalバージョン（デフォルト: `v1.4.1`）現状は`v1.4.1`のみに対応。
 - `--job_name` ジョブ名（デフォルト: `0182_intg_eval`）

--- a/evaluation/installers/intg-eval-2508/scripts/qsub.py
+++ b/evaluation/installers/intg-eval-2508/scripts/qsub.py
@@ -34,7 +34,7 @@ export NUM_GPU=$(nvidia-smi --query-gpu=name --format=csv,noheader | wc -l)
 export CUDA_VISIBLE_DEVICES=$(seq -s, 0 $((NUM_GPU-1)))
 export NUMEXPR_MAX_THREADS=192
 
-pushd {environment_dir}
+pushd {experiment_dir}/environment
 
 {swallow_template}
 
@@ -63,6 +63,7 @@ def load_args():
     # General configuration
     parser.add_argument("model_name_or_path", type=str, help="Model name or absolute path to the model directory.")
     parser.add_argument("output_dir", type=str, help="Output directory for results.")
+    parser.add_argument("--experiment_dir", type=str, default="/groups/gcg51557/experiments/0182_intg_eval_2507", help="Directory where the evaluation environment is located. Default is '/groups/gcg51557/experiments/0182_intg_eval_2507'.")
 
     # Evaluator versions
     parser.add_argument("--swallow_version", type=str, default="v202411", choices=["v202411", ""], help="Version of the swallow environment. If not specified, no swallow evaluation will be run.")
@@ -112,8 +113,6 @@ def main():
     if not hf_token:
         raise ValueError("HF_TOKEN environment variable is not set. Please set it to your Hugging Face token.")
 
-    environment_dir = Path(__file__).parent.parent
-
     qsub_script = TEMPLATE.format(
         job_name=args.job_name,
         rtype=args.rtype,
@@ -121,7 +120,7 @@ def main():
         output_dir=args.output_dir,
         hf_home=hf_home,
         hf_token=hf_token,
-        environment_dir=environment_dir,
+        experiment_dir=args.experiment_dir,
         model_name_or_path=args.model_name_or_path,
         options="\n".join(args.options),
         swallow_version=args.swallow_version,

--- a/evaluation/installers/intg-eval-2508/scripts/qsub.py
+++ b/evaluation/installers/intg-eval-2508/scripts/qsub.py
@@ -85,6 +85,9 @@ def check_args(args):
     if not os.path.isabs(args.output_dir):
         raise ValueError(f"Output directory '{args.output_dir}' must be an absolute path.")
 
+    if args.rtype == "rt_HG" and args.select != 1:
+        raise ValueError(f"Invalid selection '{args.select}' for resource type '{args.rtype}'. Only 1 GPU can be selected.")
+
 
 def main():
     args = load_args()


### PR DESCRIPTION
モデル評価パイプラインの評価ジョブ投入スクリプトに以下を修正を適用。

- `experiment_dir`引数の追加し、評価環境を配置した実験ディレクトリを変更できるようにしました。この変更により`qsub.py`の配置を自由に移動できるようになりました。
- `rtype == "rt_HG"`かつ`select != 1`の場合にエラーを出すよう修正しました。