### PR TITLE
Eliminate resource estimation in swallow evaluation

### DIFF
--- a/evaluation/installers/intg-eval-2508/scripts/qsub.py
+++ b/evaluation/installers/intg-eval-2508/scripts/qsub.py
@@ -143,7 +143,7 @@ def main():
         swallow_version=args.swallow_version,
         llm_jp_eval_version=args.llm_jp_eval_version,
         swallow_template=swallow_template,
-        llm_jp_eval_template=llm_jp_eval_template,
+        llm_jp_eval_template=llm_jp_eval_template
     )
 
     os.makedirs(os.path.join(args.output_dir, "logs"), exist_ok=True)

--- a/evaluation/installers/intg-eval-2508/scripts/run_eval.sh
+++ b/evaluation/installers/intg-eval-2508/scripts/run_eval.sh
@@ -28,7 +28,11 @@ cd $SCRIPT_DIR/../
 pushd swallow_v202411/
 bash run-eval.sh \
     $MODEL_NAME_OR_PATH \
-    $OUTPUT_DIR/swallow > $OUTPUT_DIR/logs/swallow_eval.log 2> $OUTPUT_DIR/logs/swallow_eval.err
+    $OUTPUT_DIR/swallow \
+    0.9 \
+    1 \
+    1 \
+    > $OUTPUT_DIR/logs/swallow_eval.log 2> $OUTPUT_DIR/logs/swallow_eval.err
 popd 
 
 # Run llm-jp-eval

--- a/evaluation/installers/intg-eval-2508/swallow_v202411/scripts/run-eval.sh
+++ b/evaluation/installers/intg-eval-2508/swallow_v202411/scripts/run-eval.sh
@@ -13,29 +13,24 @@ set -eux -o pipefail
 ENV_DIR=environment
 source ${ENV_DIR}/scripts/environment.sh
 
+if [[ $# -ne 5 ]]; then
+    >&2 echo "Usage: $0 MODEL OUTPUT_DIR GPU_MEMORY_UTILIZATION TENSOR_PARALLEL_SIZE DATA_PARALLEL_SIZE"
+    exit 1
+fi
+
 # Arguments
 MODEL=$1
-OUTPUT_DIR=${2:-results/${MODEL}}
-NUM_PARAMETERS_IN_BILLION=${3:--1}
+OUTPUT_DIR=$2
+GPU_MEMORY_UTILIZATION=$3
+TENSOR_PARALLEL_SIZE=$4
+DATA_PARALLEL_SIZE=$5
+
 
 # Create OUTPUT_DIR if it does not exist
 mkdir -p $OUTPUT_DIR/results
 
 # Convert OUTPUT_DIR to an absolute path
 OUTPUT_DIR=$(realpath $OUTPUT_DIR)
-
-# Set GPU_MEM_PROPORTION
-if [ "$NUM_PARAMETERS_IN_BILLION" -eq -1 ]; then
-    NUM_PARAMETERS_IN_BILLION=$(${ENV_DIR}/venv-harness/bin/python3 ./scripts/count_params_billion.py $MODEL)
-fi
-
-# Estimate the proportion of GPU MEMORY NEEDED
-GPU_MEM_PROPORTION=""
-TARGETED_DP_SIZE=""
-TARGETED_TP_SIZE=""
-. scripts/estimate_vllm_memory_usage.sh
-estimate_vllm_memory_tpdp $NUM_PARAMETERS_IN_BILLION GPU_MEM_PROPORTION TARGETED_TP_SIZE TARGETED_DP_SIZE
-echo "VLLM TPDP CONFIG" $NUM_PARAMETERS_IN_BILLION B $GPU_MEM_PROPORTION $TARGETED_TP_SIZE $TARGETED_DP_SIZE
 
 # fixed vars
 EVAL_DIR=${ENV_DIR}/src/swallow-evaluation
@@ -44,7 +39,7 @@ HARNESS_SCRIPT_PATH=${EVAL_DIR}/scripts/evaluate_english.sh
 
 source ${ENV_DIR}/venv-harness/bin/activate
 pushd ${EVAL_DIR}
-bash scripts/evaluate_english-vllm.sh $MODEL $GPU_MEM_PROPORTION $OUTPUT_DIR $TARGETED_TP_SIZE $TARGETED_DP_SIZE
+bash scripts/evaluate_english-vllm.sh $MODEL $GPU_MEMORY_UTILIZATION $OUTPUT_DIR $TENSOR_PARALLEL_SIZE $DATA_PARALLEL_SIZE
 popd
 deactivate   
 


### PR DESCRIPTION
このプルリクエストはSwallowでの評価時に `gpu_memory_utilization`, `tensor_parallel_size`, `data_parallel_size` を推定することをやめ、ユーザーが指定できるようにする。デフォルト値にはvLLMのものを採用した。

Ref:

- https://llmjp.slack.com/archives/C08SL84HX8X/p1757571261670659